### PR TITLE
Integrate AzureChatOpenAI as the primary LLM

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,8 @@
-# GEMINI_API_KEY=
+# Azure OpenAI environment variables
+AZURE_OPENAI_API_KEY="your_azure_openai_api_key_here"
+AZURE_OPENAI_ENDPOINT="your_azure_openai_endpoint_here"
+AZURE_OPENAI_API_VERSION="your_azure_api_version_here"
+AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="your_chat_deployment_name_here"
+
+# Google API Key for Search
+GOOGLE_API_KEY="your_google_api_key_for_search_here"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11,<4.0"
 dependencies = [
     "langgraph>=0.2.6",
     "langchain>=0.3.19",
-    "langchain-google-genai",
+    "langchain-openai>=0.0.5",
     "python-dotenv>=1.0.1",
     "langgraph-sdk>=0.1.57",
     "langgraph-cli",

--- a/backend/src/agent/configuration.py
+++ b/backend/src/agent/configuration.py
@@ -9,21 +9,21 @@ class Configuration(BaseModel):
     """The configuration for the agent."""
 
     query_generator_model: str = Field(
-        default="gemini-2.0-flash",
+        default="gpt-4.1-mini",
         metadata={
             "description": "The name of the language model to use for the agent's query generation."
         },
     )
 
     reflection_model: str = Field(
-        default="gemini-2.5-flash-preview-04-17",
+        default="gpt-4.1-mini",
         metadata={
             "description": "The name of the language model to use for the agent's reflection."
         },
     )
 
     answer_model: str = Field(
-        default="gemini-2.5-pro-preview-05-06",
+        default="gpt-4.1-mini",
         metadata={
             "description": "The name of the language model to use for the agent's answer."
         },


### PR DESCRIPTION
This commit modifies the codebase to use AzureChatOpenAI instead of Gemini.

Key changes include:
- Updated dependencies in `pyproject.toml` to include `langchain-openai` and remove `langchain-google-genai`.
- Modified `backend/src/agent/configuration.py` to use "gpt-4.1-mini" as the default model.
- Updated `backend/src/agent/graph.py` and `backend/.env.example` to handle Azure OpenAI environment variables (`AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_VERSION`, `AZURE_OPENAI_CHAT_DEPLOYMENT_NAME`).
- Replaced all `ChatGoogleGenerativeAI` instantiations with `AzureChatOpenAI` in `backend/src/agent/graph.py`.
- Maintained existing `temperature` and `max_retries` parameters. The `with_structured_output` method is compatible with AzureChatOpenAI.
- Updated Google Search API usage in `backend/src/agent/graph.py` to use a new `GOOGLE_API_KEY` environment variable instead of the Gemini key.

You can perform testing after these changes are applied.